### PR TITLE
Parser tests refctoring 

### DIFF
--- a/packages/de1/tests/de1/__snapshots__/parser.test.ts.snap
+++ b/packages/de1/tests/de1/__snapshots__/parser.test.ts.snap
@@ -2,77 +2,77 @@
 
 exports[`parser char processes a $type 1`] = `
 Object {
-  "value": 18,
+  "value": 12,
 }
 `;
 
 exports[`parser char processes a $type 2`] = `
 Object {
-  "val": "18",
+  "val": "12",
 }
 `;
 
 exports[`parser int processes a $type 1`] = `
 Object {
-  "value": 305419896,
+  "value": 12345678,
 }
 `;
 
 exports[`parser int processes a $type 2`] = `
 Object {
-  "val": "305419896",
+  "val": "12345678",
 }
 `;
 
 exports[`parser intSigned processes a $type 1`] = `
 Object {
-  "value": 305419896,
+  "value": 12345678,
 }
 `;
 
 exports[`parser intSigned processes a $type 2`] = `
 Object {
-  "val": "305419896",
+  "val": "12345678",
 }
 `;
 
 exports[`parser methods can be chained to create an object 1`] = `
 Object {
-  "char": 18,
-  "int": 305419896,
-  "intSigned": 305419896,
-  "sha": "12345678",
-  "short": 4660,
+  "char": 12,
+  "int": 12345678,
+  "intSigned": 12345678,
+  "sha": "bc614e",
+  "short": 1234,
 }
 `;
 
 exports[`parser sha processes a $type 1`] = `
 Object {
-  "value": "12345678",
+  "value": "bc614e",
 }
 `;
 
 exports[`parser short processes a $type 1`] = `
 Object {
-  "value": 4660,
+  "value": 1234,
 }
 `;
 
 exports[`parser short processes a $type 2`] = `
 Object {
-  "val": "4660",
+  "val": "1234",
 }
 `;
 
 exports[`parser variables can be nested 1`] = `
 Object {
   "one": Object {
-    "a": 18,
-    "b": 18,
+    "a": 12,
+    "b": 12,
   },
   "two": Object {
-    "a": 18,
-    "b": 18,
+    "a": 12,
+    "b": 12,
   },
 }
 `;

--- a/packages/de1/tests/de1/__snapshots__/parser.test.ts.snap
+++ b/packages/de1/tests/de1/__snapshots__/parser.test.ts.snap
@@ -42,12 +42,6 @@ Object {
 }
 `;
 
-exports[`parser sha processes a $type 2`] = `
-Object {
-  "val": "12345678",
-}
-`;
-
 exports[`parser short processes a $type 1`] = `
 Object {
   "value": 4660,

--- a/packages/de1/tests/de1/__snapshots__/parser.test.ts.snap
+++ b/packages/de1/tests/de1/__snapshots__/parser.test.ts.snap
@@ -36,6 +36,16 @@ Object {
 }
 `;
 
+exports[`parser methods can be chained to create an object 1`] = `
+Object {
+  "char": 18,
+  "int": 305419896,
+  "intSigned": 305419896,
+  "sha": "12345678",
+  "short": 4660,
+}
+`;
+
 exports[`parser sha processes a $type 1`] = `
 Object {
   "value": "12345678",
@@ -51,5 +61,18 @@ Object {
 exports[`parser short processes a $type 2`] = `
 Object {
   "val": "4660",
+}
+`;
+
+exports[`parser variables can be nested 1`] = `
+Object {
+  "one": Object {
+    "a": 18,
+    "b": 18,
+  },
+  "two": Object {
+    "a": 18,
+    "b": 18,
+  },
 }
 `;

--- a/packages/de1/tests/de1/__snapshots__/parser.test.ts.snap
+++ b/packages/de1/tests/de1/__snapshots__/parser.test.ts.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parser char processes a $type 1`] = `
+Object {
+  "value": 18,
+}
+`;
+
+exports[`parser char processes a $type 2`] = `
+Object {
+  "val": "18",
+}
+`;
+
+exports[`parser int processes a $type 1`] = `
+Object {
+  "value": 305419896,
+}
+`;
+
+exports[`parser int processes a $type 2`] = `
+Object {
+  "val": "305419896",
+}
+`;
+
+exports[`parser intSigned processes a $type 1`] = `
+Object {
+  "value": 305419896,
+}
+`;
+
+exports[`parser intSigned processes a $type 2`] = `
+Object {
+  "val": "305419896",
+}
+`;
+
+exports[`parser sha processes a $type 1`] = `
+Object {
+  "value": "12345678",
+}
+`;
+
+exports[`parser sha processes a $type 2`] = `
+Object {
+  "val": "12345678",
+}
+`;
+
+exports[`parser short processes a $type 1`] = `
+Object {
+  "value": 4660,
+}
+`;
+
+exports[`parser short processes a $type 2`] = `
+Object {
+  "val": "4660",
+}
+`;

--- a/packages/de1/tests/de1/parser.test.ts
+++ b/packages/de1/tests/de1/parser.test.ts
@@ -37,12 +37,14 @@ describe("parser", () => {
     ${"intSigned"} | ${intSigned} | ${getBuffer(4, intSigned, true)} | ${true}
     ${"sha"}       | ${sha}       | ${getBuffer(4, sha, true)}       | ${false}
   `("$fn processes a $type", ({ buffer, fn, value, process }: EachRecord) => {
-    const processor = jest.fn(v => v.toString());
     const parsed = new Parser(buffer)[fn]("value");
-    const processed = new Parser(buffer)[fn]("val", processor);
     expect(parsed.vars()).toMatchSnapshot();
-    expect(processed.vars()).toMatchSnapshot();
-    if (process) expect(processor).toHaveBeenCalledWith(value);
+    if (process) {
+      const processor = jest.fn(v => v.toString());
+      const processed = new Parser(buffer)[fn]("val", processor);
+      expect(processed.vars()).toMatchSnapshot();
+      expect(processor).toHaveBeenCalledWith(value);
+    }
   });
 
   /*

--- a/packages/de1/tests/de1/parser.test.ts
+++ b/packages/de1/tests/de1/parser.test.ts
@@ -10,11 +10,11 @@ type EachRecord = {
 };
 
 describe("parser", () => {
-  const char = 0x12;
-  const short = 0x1234;
-  const int = 0x12345678;
-  const intSigned = 0x12345678;
-  const sha = 0x12345678;
+  const char = 12;
+  const short = 1234;
+  const int = 12345678;
+  const intSigned = 12345678;
+  const sha = 12345678;
 
   const charBuffer = getBuffer(1, char, false);
   const shortBuffer = getBuffer(2, short, false);

--- a/packages/de1/tests/de1/parser.test.ts
+++ b/packages/de1/tests/de1/parser.test.ts
@@ -16,6 +16,12 @@ describe("parser", () => {
   const intSigned = 0x12345678;
   const sha = 0x12345678;
 
+  const charBuffer = getBuffer(1, char, false);
+  const shortBuffer = getBuffer(2, short, false);
+  const intBuffer = getBuffer(4, int, false);
+  const intSignedBuffer = getBuffer(4, intSigned, true);
+  const shaBuffer = getBuffer(4, sha, true);
+
   function getBuffer(length: number, val: number, signed: boolean): Buffer {
     const buffer = Buffer.alloc(length);
     if (signed) buffer.writeIntBE(val, 0, length);
@@ -30,12 +36,12 @@ describe("parser", () => {
   });
 
   test.each`
-    fn             | value        | buffer                           | process
-    ${"char"}      | ${char}      | ${getBuffer(1, char, false)}     | ${true}
-    ${"short"}     | ${short}     | ${getBuffer(2, short, false)}    | ${true}
-    ${"int"}       | ${int}       | ${getBuffer(4, int, false)}      | ${true}
-    ${"intSigned"} | ${intSigned} | ${getBuffer(4, intSigned, true)} | ${true}
-    ${"sha"}       | ${sha}       | ${getBuffer(4, sha, true)}       | ${false}
+    fn             | value        | buffer             | process
+    ${"char"}      | ${char}      | ${charBuffer}      | ${true}
+    ${"short"}     | ${short}     | ${shortBuffer}     | ${true}
+    ${"int"}       | ${int}       | ${intBuffer}       | ${true}
+    ${"intSigned"} | ${intSigned} | ${intSignedBuffer} | ${true}
+    ${"sha"}       | ${sha}       | ${shaBuffer}       | ${false}
   `("$fn processes a $type", ({ buffer, fn, value, process }: EachRecord) => {
     const parsed = new Parser(buffer)[fn]("value");
     expect(parsed.vars()).toMatchSnapshot();
@@ -47,36 +53,35 @@ describe("parser", () => {
     }
   });
 
-  /*
   test("methods can be chained to create an object", () => {
-    const buffer = Buffer.alloc(11);
-    buffer.writeUInt8(char, 0);
-    buffer.writeUInt16BE(short, 1);
-    buffer.writeUInt32BE(int, 3);
-    buffer.writeInt32BE(intSigned, 7);
+    const buffer = Buffer.concat([
+      charBuffer,
+      shortBuffer,
+      intBuffer,
+      intSignedBuffer,
+      shaBuffer,
+    ]);
     const parser = new Parser(buffer)
       .char("char")
       .short("short")
       .int("int")
-      .intSigned("intSigned");
-    expect(parser.vars()).toStrictEqual(values);
+      .intSigned("intSigned")
+      .sha("sha");
+    expect(parser.vars()).toMatchSnapshot();
   });
 
   test("variables can be nested", () => {
-    const { char } = values;
-    const buffer = Buffer.alloc(7);
-    buffer.writeUInt8(char, 0);
-    buffer.writeUInt8(char, 1);
-    buffer.writeUInt8(char, 2);
-    buffer.writeUInt8(char, 3);
+    const buffer = Buffer.concat([
+      charBuffer,
+      charBuffer,
+      charBuffer,
+      charBuffer,
+    ]);
     const parser = new Parser(buffer)
       .char("one.a")
       .char("one.b")
       .char("two.a")
       .char("two.b");
-    expect(parser.vars()).toStrictEqual({
-      one: { a: char, b: char },
-      two: { a: char, b: char },
-    });
-  }); */
+    expect(parser.vars()).toMatchSnapshot();
+  });
 });

--- a/packages/de1/tests/de1/serializer.test.ts
+++ b/packages/de1/tests/de1/serializer.test.ts
@@ -4,9 +4,7 @@ type SerializerMethod = "char" | "short" | "int" | "intSigned" | "sha";
 
 type EachRecord = {
   fn: SerializerMethod;
-  length: number;
   value: number;
-  signed: boolean;
 };
 
 describe("serializer", () => {


### PR DESCRIPTION
Remodeled parser tests to use snapshots throughout the test. The snapshots themselves should still be readable as the numbers used as input are also the numbers that are returned.