### PR TITLE
Run workflow when PR exits draft state

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Workflow
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   build:


### PR DESCRIPTION
Coveralls comment isn’t triggered when working with draft PRs, hoping this will remedy that as ‘ready_for_review’ isn’t enabled by default. 